### PR TITLE
Add team account session and standardize headers with cdc-backend repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Getting Started (Contributors Only)
+# Getting Started (Contributors Only)
 
 1. Clone this repo and the backend repo (cdc-backend)
 2. Grab the secrets
@@ -6,11 +6,11 @@
 
 ---
 
-## About Calgary Distress Center
+# About Calgary Distress Center
 
 todo
 
-### Team
+# Team
 
 Project Lead: [Ahmed Hamodi](https://github.com/ahmedhamodi)\
 Product Manager: [Aaron Abraham](https://github.com/aaronabraham311)\
@@ -19,21 +19,21 @@ Developers: [Jay Dhulia](https://github.com/jaydhulia), [Dhruvin Balar](https://
 
 ---
 
-## Local Development Setup
+# Local Development Setup
 
-### Secrets
+## Secrets
 
 In the root directory, copy the .env.example file into .env and request the secrets from the Project Lead.
 
-### Frontend
+## Frontend
 
-#### Dependencies
+### Dependencies
 
 On a fresh clone of the repository, you need to run `npm install` to install the necessary dependencies for the frontend code.
 
 When you pull in changes from master to your local repository and you see changes to `package.json`, that is also an indication that you need to run `npm install` before running the code.
 
-#### Adding dependencies
+### Adding dependencies
 
 Once you find a helper library that you wish to use, you can install it via `npm install <name-of-package>`. This will modify the package.json and package-lock.json files.
 
@@ -45,11 +45,11 @@ npm install eslint-plugin-prettier
 
 Please ensure to include changes to this file in your pull request.
 
-#### Node version
+### Node version
 
 To minimize unexpected behaviours, please ensure you are using node v14.16.0. Can find a link to the installation [here](https://nodejs.org/en/download/).
 
-#### Running code
+### Running code
 
 To run the frontend code, you can run the following in the root directory:
 
@@ -63,10 +63,16 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 The page will reload if you make edits.
 
-### Backend
+### Admin account
+
+We have a test account for everyone to use (unless you wish to make an account yourself, which is also fine).
+
+The email is: `distresscenter@test.org`. Reach out to the project lead for the password.
+
+## Backend
 
 See cdc-backend for backend setup.
 
-## Deployment
+# Deployment
 
 todo


### PR DESCRIPTION
Creating a test account (can see it in Firestore). Added info to the readme to deal with this.

Also there was a recent change in cdc-backend repo which changed the headers to be a level up. Doing the same change here for consistency.