### PR TITLE
Scene card setup and drag and drop functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2744,6 +2744,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
@@ -2836,6 +2845,17 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.16.tgz",
+      "integrity": "sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/react-transition-group": {
@@ -5053,6 +5073,14 @@
       "integrity": "sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==",
       "requires": {
         "postcss": "^7.0.5"
+      }
+    },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "css-color-names": {
@@ -10746,6 +10774,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -13181,6 +13214,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13241,6 +13279,20 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.7",
         "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "react-beautiful-dnd": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
+      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
       }
     },
     "react-dev-utils": {
@@ -13368,6 +13420,19 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-redux": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.3.tgz",
+      "integrity": "sha512-ZhAmQ1lrK+Pyi0ZXNMUZuYxYAZd59wFuVDGUt536kSGdD0ya9Q7BfsE95E3TsFLE3kOSFp5m6G5qbatE+Ic1+w==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/react-redux": "^7.1.16",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
+      }
     },
     "react-refresh": {
       "version": "0.8.3",
@@ -13610,6 +13675,15 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
+      }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regenerate": {
@@ -15932,6 +16006,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-memo-one": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "firebase": "^8.3.1",
     "is-empty": "^1.2.0",
     "react": "^17.0.1",
+    "react-beautiful-dnd": "^13.1.0",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",

--- a/src/Components/Admin/EnvironmentEditor/environment.js
+++ b/src/Components/Admin/EnvironmentEditor/environment.js
@@ -1,11 +1,13 @@
-import React from "react";
+import React, { useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
 import AccountBalanceIcon from "@material-ui/icons/AccountBalance";
 import AddIcon from "@material-ui/icons/Add";
+import { DragDropContext, Droppable } from "react-beautiful-dnd";
 
 import Navbar from "../navbar";
 import EnvironmentBar from "./environmentBar";
+import SceneCard from "./sceneCard";
 
 const useStyles = makeStyles((theme) => ({
     page: {
@@ -13,6 +15,9 @@ const useStyles = makeStyles((theme) => ({
     },
     container: {
         paddingTop: theme.spacing(12),
+    },
+    dragAndDropContainer: {
+        display: "flex",
     },
     emptyButtonsContainer: {
         display: "flex",
@@ -40,6 +45,49 @@ const useStyles = makeStyles((theme) => ({
 
 export default function EnvironmentEditor() {
     const classes = useStyles();
+    const [scenes, setScenes] = useState([
+        {
+            id: "1",
+            name: "Scene 1",
+        },
+        {
+            id: "2",
+            name: "Scene 2",
+        },
+        {
+            id: "3",
+            name: "Scene 3",
+        },
+        {
+            id: "4",
+            name: "Scene 4",
+        },
+        {
+            id: "5",
+            name: "Scene 5",
+        },
+    ]);
+
+    const reorder = ({ scenes, startIndex, endIndex }) => {
+        const result = Array.from(scenes);
+        const [removed] = result.splice(startIndex, 1);
+        result.splice(endIndex, 0, removed);
+
+        return result;
+    };
+
+    const onDragEnd = (result) => {
+        if (!result.destination) {
+            return;
+        }
+
+        const items = reorder({
+            scenes,
+            startIndex: result.source.index,
+            endIndex: result.destination.index,
+        });
+        setScenes(items);
+    };
 
     return (
         <div>
@@ -48,24 +96,52 @@ export default function EnvironmentEditor() {
                 <EnvironmentBar />
             </div>
             <div className={classes.container}>
-                <div className={classes.emptyButtonsContainer}>
-                    <div className={classes.buttonContainer}>
-                        <Button
-                            startIcon={<AddIcon />}
-                            className={classes.button}
+                {scenes !== undefined && scenes.length !== 0 ? (
+                    <DragDropContext onDragEnd={onDragEnd}>
+                        <Droppable
+                            droppableId="droppable"
+                            direction="horizontal"
                         >
-                            New Scene from Scratch
-                        </Button>
+                            {(provided) => (
+                                <div
+                                    ref={provided.innerRef}
+                                    className={classes.dragAndDropContainer}
+                                    {...provided.droppableProps}
+                                >
+                                    {scenes.map(function (scene, index) {
+                                        return (
+                                            <div key={scene.id}>
+                                                <SceneCard
+                                                    scene={scene}
+                                                    index={index}
+                                                />
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </Droppable>
+                    </DragDropContext>
+                ) : (
+                    <div className={classes.emptyButtonsContainer}>
+                        <div className={classes.buttonContainer}>
+                            <Button
+                                startIcon={<AddIcon />}
+                                className={classes.button}
+                            >
+                                New Scene from Scratch
+                            </Button>
+                        </div>
+                        <div className={classes.buttonContainer}>
+                            <Button
+                                startIcon={<AccountBalanceIcon />}
+                                className={classes.button}
+                            >
+                                New Scene from Template
+                            </Button>
+                        </div>
                     </div>
-                    <div className={classes.buttonContainer}>
-                        <Button
-                            startIcon={<AccountBalanceIcon />}
-                            className={classes.button}
-                        >
-                            New Scene from Template
-                        </Button>
-                    </div>
-                </div>
+                )}
             </div>
         </div>
     );

--- a/src/Components/Admin/EnvironmentEditor/environment.js
+++ b/src/Components/Admin/EnvironmentEditor/environment.js
@@ -18,6 +18,8 @@ const useStyles = makeStyles((theme) => ({
     },
     dragAndDropContainer: {
         display: "flex",
+        alignItems: "center",
+        marginLeft: "16px",
     },
     emptyButtonsContainer: {
         display: "flex",

--- a/src/Components/Admin/EnvironmentEditor/sceneCard.js
+++ b/src/Components/Admin/EnvironmentEditor/sceneCard.js
@@ -4,10 +4,15 @@ import { Draggable } from "react-beautiful-dnd";
 
 const useStyles = makeStyles(() => ({
     sceneItem: {
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
         backgroundColor: "#E2E5ED",
         padding: 16,
         userSelect: "none",
-        margin: "0 8px 0 0",
+        margin: "0 16px 0 0",
+        width: "400px",
+        height: "300px",
     },
 }));
 
@@ -19,7 +24,7 @@ export default function SceneCard({ scene, index }) {
                 <div
                     ref={provided.innerRef}
                     className={classes.sceneItem}
-                    style={{ ...provided.draggableProps.style }}
+                    style={provided.draggableProps.style}
                     {...provided.draggableProps}
                     {...provided.dragHandleProps}
                 >

--- a/src/Components/Admin/EnvironmentEditor/sceneCard.js
+++ b/src/Components/Admin/EnvironmentEditor/sceneCard.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import { Draggable } from "react-beautiful-dnd";
+
+const useStyles = makeStyles(() => ({
+    sceneItem: {
+        backgroundColor: "#E2E5ED",
+        padding: 16,
+        userSelect: "none",
+        margin: "0 8px 0 0",
+    },
+}));
+
+export default function SceneCard({ scene, index }) {
+    const classes = useStyles();
+    return (
+        <Draggable key={scene.id} index={index} draggableId={scene.id}>
+            {(provided) => (
+                <div
+                    ref={provided.innerRef}
+                    className={classes.sceneItem}
+                    style={{ ...provided.draggableProps.style }}
+                    {...provided.draggableProps}
+                    {...provided.dragHandleProps}
+                >
+                    {scene.name}
+                </div>
+            )}
+        </Draggable>
+    );
+}


### PR DESCRIPTION
- Used Atlassian's react-beautiful-dnd to create drag and drop scene cards
- Did not implement handles (will push it to later ticket, very low priority)
- Implemented conditional rendering: if there are no scenes in the state, we will render the empty scene screen that was built in #30 

Environment editor with scenes (drag and drop functionality):
![Kapture 2021-04-20 at 08 59 55](https://user-images.githubusercontent.com/21224282/115418936-26faf480-a1b7-11eb-92e6-cc41dbe853bb.gif)

Environment editor without scenes:
![Kapture 2021-04-20 at 09 06 58](https://user-images.githubusercontent.com/21224282/115419801-d89a2580-a1b7-11eb-9444-43310d9d200b.gif)