### PR TITLE
Create environment flow

### DIFF
--- a/src/Components/Admin/Rooms/roomModal.js
+++ b/src/Components/Admin/Rooms/roomModal.js
@@ -36,15 +36,15 @@ export default function RoomModal({
     };
 
     const handleModalCloseClick = () => {
+        handleModalClose();
         setRoomName("");
         setRoomDescription("");
-        handleModalClose();
     };
 
     const handleModalSubmitClick = () => {
+        handleSubmit();
         setRoomName("");
         setRoomDescription("");
-        handleSubmit();
     };
 
     return (

--- a/src/Components/Admin/Rooms/roomModal.js
+++ b/src/Components/Admin/Rooms/roomModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import FormControl from "@material-ui/core/FormControl";
+import { makeStyles } from "@material-ui/core/styles";
 import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
@@ -8,11 +8,22 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogTitle from "@material-ui/core/DialogTitle";
 
+const useStyles = makeStyles(() => ({
+    textField: {
+        width: "500px",
+    },
+    buttonContainer: {
+        display: "flex",
+        justifyContent: "space-around",
+    },
+}));
+
 export default function RoomModal({
     modalOpen,
     handleModalClose,
     handleSubmit,
 }) {
+    const classes = useStyles();
     const [roomName, setRoomName] = React.useState("");
     const [roomDescription, setRoomDescription] = React.useState("");
 
@@ -33,6 +44,7 @@ export default function RoomModal({
                     <TextField
                         value={roomName}
                         onChange={handleRoomNameChange}
+                        className={classes.textField}
                     />
                 </div>
                 <div>
@@ -40,10 +52,11 @@ export default function RoomModal({
                     <TextField
                         value={roomDescription}
                         onChange={handleRoomDescriptionChange}
+                        className={classes.textField}
                     />
                 </div>
             </DialogContent>
-            <DialogActions>
+            <DialogActions className={classes.buttonContainer}>
                 <Button onClick={handleModalClose}> Cancel </Button>
                 <Button onClick={handleSubmit}> Create </Button>
             </DialogActions>

--- a/src/Components/Admin/Rooms/roomModal.js
+++ b/src/Components/Admin/Rooms/roomModal.js
@@ -35,6 +35,18 @@ export default function RoomModal({
         setRoomDescription(event.target.value);
     };
 
+    const handleModalCloseClick = () => {
+        setRoomName("");
+        setRoomDescription("");
+        handleModalClose();
+    };
+
+    const handleModalSubmitClick = () => {
+        setRoomName("");
+        setRoomDescription("");
+        handleSubmit(); 
+    }
+
     return (
         <Dialog open={modalOpen} onClose={handleModalClose}>
             <DialogTitle> New Escape Room </DialogTitle>
@@ -57,8 +69,8 @@ export default function RoomModal({
                 </div>
             </DialogContent>
             <DialogActions className={classes.buttonContainer}>
-                <Button onClick={handleModalClose}> Cancel </Button>
-                <Button onClick={handleSubmit}> Create </Button>
+                <Button onClick={handleModalCloseClick}> Cancel </Button>
+                <Button onClick={handleModalSubmitClick}> Create </Button>
             </DialogActions>
         </Dialog>
     );

--- a/src/Components/Admin/Rooms/roomModal.js
+++ b/src/Components/Admin/Rooms/roomModal.js
@@ -44,11 +44,11 @@ export default function RoomModal({
     const handleModalSubmitClick = () => {
         setRoomName("");
         setRoomDescription("");
-        handleSubmit(); 
-    }
+        handleSubmit();
+    };
 
     return (
-        <Dialog open={modalOpen} onClose={handleModalClose}>
+        <Dialog open={modalOpen} onClose={handleModalCloseClick}>
             <DialogTitle> New Escape Room </DialogTitle>
             <DialogContent>
                 <div>

--- a/src/Components/Admin/Rooms/roomModal.js
+++ b/src/Components/Admin/Rooms/roomModal.js
@@ -1,0 +1,52 @@
+import React from "react";
+import FormControl from "@material-ui/core/FormControl";
+import TextField from "@material-ui/core/TextField";
+import Typography from "@material-ui/core/Typography";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogTitle from "@material-ui/core/DialogTitle";
+
+export default function RoomModal({
+    modalOpen,
+    handleModalClose,
+    handleSubmit,
+}) {
+    const [roomName, setRoomName] = React.useState("");
+    const [roomDescription, setRoomDescription] = React.useState("");
+
+    const handleRoomNameChange = (event) => {
+        setRoomName(event.target.value);
+    };
+
+    const handleRoomDescriptionChange = (event) => {
+        setRoomDescription(event.target.value);
+    };
+
+    return (
+        <Dialog open={modalOpen} onClose={handleModalClose}>
+            <DialogTitle> New Escape Room </DialogTitle>
+            <DialogContent>
+                <div>
+                    <Typography>Room Name: </Typography>
+                    <TextField
+                        value={roomName}
+                        onChange={handleRoomNameChange}
+                    />
+                </div>
+                <div>
+                    <Typography>Room Description: </Typography>
+                    <TextField
+                        value={roomDescription}
+                        onChange={handleRoomDescriptionChange}
+                    />
+                </div>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleModalClose}> Cancel </Button>
+                <Button onClick={handleSubmit}> Create </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/src/Components/Admin/admin.js
+++ b/src/Components/Admin/admin.js
@@ -5,19 +5,21 @@ import CssBaseline from "@material-ui/core/CssBaseline";
 import Container from "@material-ui/core/Container";
 import Typography from "@material-ui/core/Typography";
 import { makeStyles } from "@material-ui/core/styles";
-import { auth } from "../../firebaseCredentials.js";
-import { UserContext } from "../../Providers/UserProviders";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import Box from "@material-ui/core/Box";
-import EscapeRooms from "./Rooms/rooms.js";
-import Assets from "./Assets/assets.js";
-import Statistics from "./Stats/stats.js";
 import AddIcon from "@material-ui/icons/Add";
 import IconButton from "@material-ui/core/IconButton";
 import MenuItem from "@material-ui/core/MenuItem";
 import Menu from "@material-ui/core/Menu";
 import { useHistory } from "react-router-dom";
+
+import { auth } from "../../firebaseCredentials.js";
+import { UserContext } from "../../Providers/UserProviders";
+import EscapeRooms from "./Rooms/rooms.js";
+import Assets from "./Assets/assets.js";
+import Statistics from "./Stats/stats.js";
+import RoomModal from "./Rooms/roomModal";
 
 function TabPanel(props) {
     const { children, value, index, ...other } = props;
@@ -108,6 +110,7 @@ export default function Admin() {
     const history = useHistory();
     const [value, setValue] = React.useState("rooms");
     const [anchorEl, setAnchorEl] = React.useState(null);
+    const [createModalOpen, setCreateModalOpen] = React.useState(false);
     const open = Boolean(anchorEl);
 
     const handleChange = (event, newValue) => {
@@ -120,6 +123,11 @@ export default function Admin() {
 
     const handleAddButtonClose = () => {
         setAnchorEl(null);
+    };
+
+    const handleCreateRoomSubmit = () => {
+        console.log("Created room ");
+        setCreateModalOpen(false);
     };
 
     return (
@@ -145,6 +153,7 @@ export default function Admin() {
                 >
                     Sign Out
                 </Button>
+
                 <div className={classes.root}>
                     <IconButton
                         className={classes.addButton}
@@ -168,8 +177,21 @@ export default function Admin() {
                         onClose={handleAddButtonClose}
                     >
                         <MenuItem>Object Upload</MenuItem>
-                        <MenuItem>New Escape Room</MenuItem>
+                        <MenuItem
+                            onClick={() => {
+                                setCreateModalOpen(true);
+                            }}
+                        >
+                            New Escape Room
+                        </MenuItem>
                     </Menu>
+                    <RoomModal
+                        modalOpen={createModalOpen}
+                        handleModalClose={() => {
+                            setCreateModalOpen(false);
+                        }}
+                        handleSubmit={handleCreateRoomSubmit}
+                    />
                     <Tabs
                         value={value}
                         indicatorColor="primary"

--- a/src/Components/Admin/admin.js
+++ b/src/Components/Admin/admin.js
@@ -125,8 +125,8 @@ export default function Admin() {
         setAnchorEl(null);
     };
 
+    // TODO: POST room details to backend
     const handleCreateRoomSubmit = () => {
-        console.log("Created room ");
         setCreateModalOpen(false);
     };
 
@@ -179,6 +179,7 @@ export default function Admin() {
                         <MenuItem>Object Upload</MenuItem>
                         <MenuItem
                             onClick={() => {
+                                setAnchorEl(null);
                                 setCreateModalOpen(true);
                             }}
                         >

--- a/src/Components/Admin/admin.js
+++ b/src/Components/Admin/admin.js
@@ -15,6 +15,8 @@ import Assets from "./Assets/assets.js";
 import Statistics from "./Stats/stats.js";
 import AddIcon from "@material-ui/icons/Add";
 import IconButton from "@material-ui/core/IconButton";
+import MenuItem from "@material-ui/core/MenuItem";
+import Menu from "@material-ui/core/Menu";
 import { useHistory } from "react-router-dom";
 
 function TabPanel(props) {
@@ -105,9 +107,19 @@ export default function Admin() {
 
     const history = useHistory();
     const [value, setValue] = React.useState("rooms");
+    const [anchorEl, setAnchorEl] = React.useState(null);
+    const open = Boolean(anchorEl);
 
     const handleChange = (event, newValue) => {
         setValue(newValue);
+    };
+
+    const handleAddButtonClick = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleAddButtonClose = () => {
+        setAnchorEl(null);
     };
 
     return (
@@ -137,9 +149,27 @@ export default function Admin() {
                     <IconButton
                         className={classes.addButton}
                         aria-label="delete"
+                        onClick={handleAddButtonClick}
                     >
                         <AddIcon />
                     </IconButton>
+                    <Menu
+                        anchorEl={anchorEl}
+                        anchorOrigin={{
+                            vertical: "top",
+                            horizontal: "center",
+                        }}
+                        transformOrigin={{
+                            vertical: "top",
+                            horizontal: "center",
+                        }}
+                        keepMounted
+                        open={open}
+                        onClose={handleAddButtonClose}
+                    >
+                        <MenuItem>Object Upload</MenuItem>
+                        <MenuItem>New Escape Room</MenuItem>
+                    </Menu>
                     <Tabs
                         value={value}
                         indicatorColor="primary"


### PR DESCRIPTION
- Added dropdown on create button
- Added generalized modal that can and should be reused for other parts of the application
- Does not add any new environment cards
    - Why did I not do this? Currently, the state of environment cards is not in the same level defined for the creation modal. Thus, in order to implement this functionality, I would need to bring the states for the environment cards to this level. I did not think it was worth the effort for this JSON method that we will probably remove in the next few weeks.
   
![Kapture 2021-04-22 at 16 23 27](https://user-images.githubusercontent.com/21224282/115792215-1c8f5500-a387-11eb-9ec7-e9a9f255af8e.gif)
