### PR TITLE
Fix Key Prop Bug

### DIFF
--- a/src/Components/Admin/Rooms/roomcard.js
+++ b/src/Components/Admin/Rooms/roomcard.js
@@ -20,7 +20,6 @@ const useStyles = makeStyles(() => ({
 }));
 
 export default function RoomCard({
-    key,
     data,
     handleEditRoomClick,
     handleDeleteRoomClick,
@@ -54,7 +53,6 @@ export default function RoomCard({
             alignItems="center"
             justify="flex-start"
             className={classes.card}
-            key={key}
         >
             <Grid
                 container


### PR DESCRIPTION
When loading the admin tab, a warning appears in the console. This is because the `key` property was being accessed within the RoomCard component, and since `key` is a special property in React, it shouldn't be accessed.

Image of console warning:
![image](https://user-images.githubusercontent.com/56518575/116950115-18e6b280-ac52-11eb-8bd8-7d1a2cf50117.png)
