### PR TITLE
Remove duplicate call to delete scene ID

### DIFF
--- a/src/Components/Admin/EnvironmentEditor/environment.js
+++ b/src/Components/Admin/EnvironmentEditor/environment.js
@@ -205,11 +205,6 @@ export default function EnvironmentEditor({
             (scene) => scene.id !== deleteSceneId
         );
 
-        const newEnvData = environment;
-        newEnvData.scene_ids = modifiedScenes.map((scene) => scene.id);
-        const newEnv = await editScenario(newEnvData, handleError);
-
-        setEnvironment(newEnv.data);
         setScenes(modifiedScenes);
         setDeleteSceneId(null);
         setDeleteModalOpen(false);


### PR DESCRIPTION
As per this change: https://github.com/uwblueprint/cdc-backend/pull/101

We no longer need to do the delete from the frontend too. It's handled in the backend.