### PR TITLE
Added "is_publishable" and "is_previewable" environment fields to the room cards

### DIFF
--- a/src/Components/Admin/Rooms/roomModal.js
+++ b/src/Components/Admin/Rooms/roomModal.js
@@ -36,14 +36,12 @@ export default function RoomModal({
     const [isPreviewable, setIsPreviewable] = React.useState(false);
 
     useEffect(() => {
-        if (room) {
-            setRoomName(room.name);
-            setFriendlyName(room.friendly_name);
-            setRoomDescription(room.description);
-            setIsPublished(room.is_published);
-            setIsPreviewable(room.is_previewable);
-            setRoomSolveTime(room.expected_solve_time);
-        }
+        setRoomName(room ? room.name : "");
+        setFriendlyName(room ? room.friendly_name : "");
+        setRoomDescription(room ? room.description : "");
+        setIsPublished(room ? room.is_published : false);
+        setIsPreviewable(room ? room.is_previewable : false);
+        setRoomSolveTime(room ? room.expected_solve_time : "");
     }, [room]);
 
     const handleRoomNameChange = (event) => {
@@ -62,16 +60,6 @@ export default function RoomModal({
         setRoomSolveTime(event.target.value);
     };
 
-    const handleModalCloseClick = () => {
-        handleModalClose();
-        setRoomName("");
-        setRoomDescription("");
-        setFriendlyName("");
-        setRoomSolveTime("");
-        setIsPublished(false);
-        setIsPreviewable(false);
-    };
-
     const handleModalSubmitClick = () => {
         if (isEdit) {
             handleSubmit({
@@ -82,9 +70,6 @@ export default function RoomModal({
                 is_previewable: isPreviewable,
                 expected_solve_time: roomSolveTime,
             });
-            setRoomSolveTime("");
-            setIsPublished(false);
-            setIsPreviewable(false);
         } else {
             handleSubmit({
                 name: roomName,
@@ -92,9 +77,6 @@ export default function RoomModal({
                 friendly_name: friendlyName,
             });
         }
-        setRoomName("");
-        setRoomDescription("");
-        setFriendlyName("");
     };
 
     const handleIsPublishedClick = () => {
@@ -106,7 +88,7 @@ export default function RoomModal({
     };
 
     return (
-        <Dialog open={modalOpen} onClose={handleModalCloseClick}>
+        <Dialog open={modalOpen} onClose={handleModalClose}>
             <DialogTitle>
                 {isEdit ? "Edit Escape Room" : "New Escape Room"}
             </DialogTitle>
@@ -175,7 +157,7 @@ export default function RoomModal({
                 )}
             </DialogContent>
             <DialogActions className={classes.buttonContainer}>
-                <Button onClick={handleModalCloseClick}> Cancel </Button>
+                <Button onClick={handleModalClose}> Cancel </Button>
                 <Button onClick={handleModalSubmitClick}>
                     {isEdit ? "Edit" : "Create"}
                 </Button>

--- a/src/Components/Admin/Rooms/roomModal.js
+++ b/src/Components/Admin/Rooms/roomModal.js
@@ -98,19 +98,11 @@ export default function RoomModal({
     };
 
     const handleIsPublishedClick = () => {
-        if (isPublished === true) {
-            setIsPublished(false);
-        } else {
-            setIsPublished(true);
-        }
+        setIsPublished(!isPublished);
     };
 
     const handleIsPreviewableClick = () => {
-        if (isPreviewable === true) {
-            setIsPreviewable(false);
-        } else {
-            setIsPreviewable(true);
-        }
+        setIsPreviewable(!isPreviewable);
     };
 
     return (
@@ -149,7 +141,7 @@ export default function RoomModal({
                         className={classes.textField}
                     />
                 </div>
-                {isEdit ? (
+                {isEdit && (
                     <div>
                         <Typography component="div" variant="h5">
                             Expected Solve Time:{" "}
@@ -180,7 +172,7 @@ export default function RoomModal({
                             label="Room is Previewable"
                         />
                     </div>
-                ) : null}
+                )}
             </DialogContent>
             <DialogActions className={classes.buttonContainer}>
                 <Button onClick={handleModalCloseClick}> Cancel </Button>

--- a/src/Components/Admin/Rooms/roomModal.js
+++ b/src/Components/Admin/Rooms/roomModal.js
@@ -7,6 +7,8 @@ import Dialog from "@material-ui/core/Dialog";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogTitle from "@material-ui/core/DialogTitle";
+import Checkbox from "@material-ui/core/Checkbox";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
 
 const useStyles = makeStyles(() => ({
     textField: {
@@ -29,12 +31,18 @@ export default function RoomModal({
     const [roomName, setRoomName] = React.useState("");
     const [friendlyName, setFriendlyName] = React.useState("");
     const [roomDescription, setRoomDescription] = React.useState("");
+    const [roomSolveTime, setRoomSolveTime] = React.useState("");
+    const [isPublished, setIsPublished] = React.useState(false);
+    const [isPreviewable, setIsPreviewable] = React.useState(false);
 
     useEffect(() => {
         if (room) {
             setRoomName(room.name);
             setFriendlyName(room.friendly_name);
             setRoomDescription(room.description);
+            setIsPublished(room.is_published);
+            setIsPreviewable(room.is_previewable);
+            setRoomSolveTime(room.expected_solve_time);
         }
     }, [room]);
 
@@ -50,11 +58,18 @@ export default function RoomModal({
         setFriendlyName(event.target.value);
     };
 
+    const handleRoomSolveTimeChange = (event) => {
+        setRoomSolveTime(event.target.value);
+    };
+
     const handleModalCloseClick = () => {
         handleModalClose();
         setRoomName("");
         setRoomDescription("");
         setFriendlyName("");
+        setRoomSolveTime("");
+        setIsPublished(false);
+        setIsPreviewable(false);
     };
 
     const handleModalSubmitClick = () => {
@@ -62,10 +77,31 @@ export default function RoomModal({
             name: roomName,
             description: roomDescription,
             friendly_name: friendlyName,
+            is_published: isPublished,
+            is_previewable: isPreviewable,
         });
         setRoomName("");
         setRoomDescription("");
         setFriendlyName("");
+        setRoomSolveTime("");
+        setIsPublished(false);
+        setIsPreviewable(false);
+    };
+
+    const handleIsPublishedClick = () => {
+        if (isPublished === true) {
+            setIsPublished(false);
+        } else {
+            setIsPublished(true);
+        }
+    };
+
+    const handleIsPreviewableClick = () => {
+        if (isPreviewable === true) {
+            setIsPreviewable(false);
+        } else {
+            setIsPreviewable(true);
+        }
     };
 
     return (
@@ -101,6 +137,38 @@ export default function RoomModal({
                     <TextField
                         value={roomDescription}
                         onChange={handleRoomDescriptionChange}
+                        className={classes.textField}
+                    />
+                </div>
+                <div>
+                    <FormControlLabel
+                        value="Room is Published"
+                        control={
+                            <Checkbox
+                                onClick={handleIsPublishedClick}
+                                checked={isPublished}
+                            />
+                        }
+                        label="Room is Published"
+                    />
+                    <FormControlLabel
+                        value="Room is Previewable"
+                        control={
+                            <Checkbox
+                                onClick={handleIsPreviewableClick}
+                                checked={isPreviewable}
+                            />
+                        }
+                        label="Room is Previewable"
+                    />
+                </div>
+                <div>
+                    <Typography component="div" variant="h5">
+                        Expected Solve Time:{" "}
+                    </Typography>
+                    <TextField
+                        value={roomSolveTime}
+                        onChange={handleRoomSolveTimeChange}
                         className={classes.textField}
                     />
                 </div>

--- a/src/Components/Admin/Rooms/roomModal.js
+++ b/src/Components/Admin/Rooms/roomModal.js
@@ -73,19 +73,28 @@ export default function RoomModal({
     };
 
     const handleModalSubmitClick = () => {
-        handleSubmit({
-            name: roomName,
-            description: roomDescription,
-            friendly_name: friendlyName,
-            is_published: isPublished,
-            is_previewable: isPreviewable,
-        });
+        if (isEdit) {
+            handleSubmit({
+                name: roomName,
+                description: roomDescription,
+                friendly_name: friendlyName,
+                is_published: isPublished,
+                is_previewable: isPreviewable,
+                expected_solve_time: roomSolveTime,
+            });
+            setRoomSolveTime("");
+            setIsPublished(false);
+            setIsPreviewable(false);
+        } else {
+            handleSubmit({
+                name: roomName,
+                description: roomDescription,
+                friendly_name: friendlyName,
+            });
+        }
         setRoomName("");
         setRoomDescription("");
         setFriendlyName("");
-        setRoomSolveTime("");
-        setIsPublished(false);
-        setIsPreviewable(false);
     };
 
     const handleIsPublishedClick = () => {
@@ -140,38 +149,38 @@ export default function RoomModal({
                         className={classes.textField}
                     />
                 </div>
-                <div>
-                    <FormControlLabel
-                        value="Room is Published"
-                        control={
-                            <Checkbox
-                                onClick={handleIsPublishedClick}
-                                checked={isPublished}
-                            />
-                        }
-                        label="Room is Published"
-                    />
-                    <FormControlLabel
-                        value="Room is Previewable"
-                        control={
-                            <Checkbox
-                                onClick={handleIsPreviewableClick}
-                                checked={isPreviewable}
-                            />
-                        }
-                        label="Room is Previewable"
-                    />
-                </div>
-                <div>
-                    <Typography component="div" variant="h5">
-                        Expected Solve Time:{" "}
-                    </Typography>
-                    <TextField
-                        value={roomSolveTime}
-                        onChange={handleRoomSolveTimeChange}
-                        className={classes.textField}
-                    />
-                </div>
+                {isEdit ? (
+                    <div>
+                        <Typography component="div" variant="h5">
+                            Expected Solve Time:{" "}
+                        </Typography>
+                        <TextField
+                            value={roomSolveTime}
+                            onChange={handleRoomSolveTimeChange}
+                            className={classes.textField}
+                        />
+                        <FormControlLabel
+                            value="Room is Published"
+                            control={
+                                <Checkbox
+                                    onClick={handleIsPublishedClick}
+                                    checked={isPublished}
+                                />
+                            }
+                            label="Room is Published"
+                        />
+                        <FormControlLabel
+                            value="Room is Previewable"
+                            control={
+                                <Checkbox
+                                    onClick={handleIsPreviewableClick}
+                                    checked={isPreviewable}
+                                />
+                            }
+                            label="Room is Previewable"
+                        />
+                    </div>
+                ) : null}
             </DialogContent>
             <DialogActions className={classes.buttonContainer}>
                 <Button onClick={handleModalCloseClick}> Cancel </Button>

--- a/src/Components/Admin/admin.js
+++ b/src/Components/Admin/admin.js
@@ -193,6 +193,7 @@ export default function Admin() {
         friendly_name,
         is_published,
         is_previewable,
+        expected_solve_time,
     }) => {
         setEditModalOpen(false);
         const resp = await editScenario(
@@ -204,7 +205,7 @@ export default function Admin() {
                 scene_ids: editRoom.scene_ids,
                 is_published,
                 is_previewable,
-                expected_solve_time: editRoom.expected_solve_time,
+                expected_solve_time,
             },
             handleError
         );

--- a/src/Components/Admin/admin.js
+++ b/src/Components/Admin/admin.js
@@ -191,6 +191,8 @@ export default function Admin() {
         name,
         description,
         friendly_name,
+        is_published,
+        is_previewable,
     }) => {
         setEditModalOpen(false);
         const resp = await editScenario(
@@ -200,8 +202,9 @@ export default function Admin() {
                 friendly_name,
                 description,
                 scene_ids: editRoom.scene_ids,
-                is_published: editRoom.is_published,
-                is_previewable: editRoom.is_previewable,
+                is_published,
+                is_previewable,
+                expected_solve_time: editRoom.expected_solve_time,
             },
             handleError
         );

--- a/src/lib/scenarioEndpoints.js
+++ b/src/lib/scenarioEndpoints.js
@@ -48,6 +48,7 @@ export const editScenario = async (
         scene_ids,
         is_published,
         is_previewable,
+        expected_solve_time,
     },
     handleError
 ) => {
@@ -59,6 +60,7 @@ export const editScenario = async (
             scene_ids,
             is_published,
             is_previewable,
+            expected_solve_time,
         });
         return response;
     } catch (error) {


### PR DESCRIPTION
Pretty much what the title of the PR suggests is what I did. The functionality works for editing rooms and was decided to not include these fields for creating rooms. Upon Ahmed's suggestion, I also added an "expected solve time" field - below the checkboxes; currently its value is fixed.

Let me know if this loom recording is slow for you guys - for some reason the playback was slow for me. I can retake it.
https://www.loom.com/share/8368782620a04bb78f3d517ef5f3b965
