### PR TITLE
View transitions work

### DIFF
--- a/src/Components/Admin/EnvironmentEditor/environment.js
+++ b/src/Components/Admin/EnvironmentEditor/environment.js
@@ -3,11 +3,12 @@ import { makeStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
 import AccountBalanceIcon from "@material-ui/icons/AccountBalance";
 import AddIcon from "@material-ui/icons/Add";
-import { DragDropContext, Droppable } from "react-beautiful-dnd";
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 
 import Navbar from "../navbar";
 import EnvironmentBar from "./environmentBar";
 import SceneCard from "./sceneCard";
+import TransitionCard from "./transitionCard";
 import SceneModal from "./sceneModal";
 import DeleteModal from "../common/deleteModal";
 import { getScenario, editScenario } from "../../../lib/scenarioEndpoints";
@@ -22,6 +23,9 @@ import { useErrorHandler } from "react-error-boundary";
 const useStyles = makeStyles((theme) => ({
     page: {
         marginTop: theme.spacing(8),
+    },
+    sceneAndTransitionContainer: {
+        minWidth: 600,
     },
     container: {
         paddingTop: theme.spacing(12),
@@ -69,6 +73,10 @@ export default function EnvironmentEditor({
     const [editSceneInfo, setEditSceneInfo] = useState({});
     const [deleteModalOpen, setDeleteModalOpen] = useState(false);
     const [deleteSceneId, setDeleteSceneId] = React.useState(null);
+    const [editTransitionInfo, setEditTransitionInfo] = useState({});
+    const [editTransitionModalOpen, setEditTransitionModalOpen] = useState(
+        false
+    );
 
     useEffect(() => {
         const getEnvironment = async () => {
@@ -159,9 +167,22 @@ export default function EnvironmentEditor({
         setEditModalOpen(true);
     };
 
+    const onTransitionEditClick = (sceneId) => {
+        const scene = scenes.find((scene) => scene.id === sceneId);
+
+        // TODO: get transition information (have to go up to scenario and match index from scene table)
+        setEditTransitionInfo(scene);
+        setEditTransitionModalOpen(true);
+    };
+
     const onEditModalClose = () => {
         setEditModalOpen(false);
         setEditSceneInfo({});
+    };
+
+    const onTransitionModalClose = () => {
+        setEditTransitionModalOpen(false);
+        setEditTransitionInfo({});
     };
 
     const onEditModalSubmit = async (name, background_id) => {
@@ -186,6 +207,12 @@ export default function EnvironmentEditor({
         const copiedScenes = [...scenes];
         copiedScenes[replaceIndex] = resp.data;
         setScenes(copiedScenes);
+    };
+
+    const onTransitionModalSubmit = async () => {
+        setEditTransitionModalOpen(false);
+
+        // TODO: edit transition data upon edit
     };
 
     const onDeleteButtonClick = (sceneId) => {
@@ -232,18 +259,45 @@ export default function EnvironmentEditor({
                                     >
                                         {scenes.map(function (scene, index) {
                                             return (
-                                                <div key={scene.id}>
-                                                    <SceneCard
-                                                        scene={scene}
-                                                        index={index}
-                                                        handleEditClick={
-                                                            onEditButtonClick
-                                                        }
-                                                        handleDeleteClick={
-                                                            onDeleteButtonClick
-                                                        }
-                                                    />
-                                                </div>
+                                                <Draggable
+                                                    key={scene.id}
+                                                    index={index}
+                                                    draggableId={scene.id.toString()}
+                                                >
+                                                    {(provided) => (
+                                                        <div
+                                                            ref={
+                                                                provided.innerRef
+                                                            }
+                                                            className={
+                                                                classes.sceneAndTransitionContainer
+                                                            }
+                                                            style={
+                                                                provided
+                                                                    .draggableProps
+                                                                    .style
+                                                            }
+                                                            {...provided.draggableProps}
+                                                            {...provided.dragHandleProps}
+                                                        >
+                                                            <SceneCard
+                                                                scene={scene}
+                                                                handleEditClick={
+                                                                    onEditButtonClick
+                                                                }
+                                                                handleDeleteClick={
+                                                                    onDeleteButtonClick
+                                                                }
+                                                            />
+                                                            <TransitionCard
+                                                                scene={scene}
+                                                                handleEditClick={
+                                                                    onTransitionEditClick
+                                                                }
+                                                            />
+                                                        </div>
+                                                    )}
+                                                </Draggable>
                                             );
                                         })}
                                     </div>
@@ -285,6 +339,13 @@ export default function EnvironmentEditor({
                 modalOpen={editModalOpen}
                 handleModalClose={onEditModalClose}
                 handleSubmit={onEditModalSubmit}
+                isEdit
+            />
+            <SceneModal
+                scene={editTransitionInfo}
+                modalOpen={editTransitionModalOpen}
+                handleModalClose={onTransitionModalClose}
+                handleSubmit={onTransitionModalSubmit}
                 isEdit
             />
             <DeleteModal

--- a/src/Components/Admin/EnvironmentEditor/transitionCard.js
+++ b/src/Components/Admin/EnvironmentEditor/transitionCard.js
@@ -6,33 +6,30 @@ import MenuItem from "@material-ui/core/MenuItem";
 import Menu from "@material-ui/core/Menu";
 
 const useStyles = makeStyles(() => ({
-    sceneItem: {
+    transitionItem: {
         display: "inline-flex",
         flexDirection: "column",
         backgroundColor: "#E2E5ED",
         padding: 16,
         userSelect: "none",
-        margin: "0 16px 0 0",
-        width: "300px",
-        height: "300px",
+        margin: "0 25px 0 0",
+        verticalAlign: "center",
+        width: "150px",
+        height: "150px",
     },
-    sceneTopRow: {
+    transitionTopRow: {
         display: "flex",
         width: "100%",
-        height: "90%",
+        height: "100px",
         justifyContent: "center",
-        marginTop: 140,
+        marginTop: 75,
     },
-    sceneBottomRow: {
+    transitionBottomRow: {
         alignSelf: "flex-end",
     },
 }));
 
-export default function SceneCard({
-    scene,
-    handleEditClick,
-    handleDeleteClick,
-}) {
+export default function TransitionCard({ scene, handleEditClick }) {
     const classes = useStyles();
     const [anchorEl, setAnchorEl] = React.useState(null);
     const open = Boolean(anchorEl);
@@ -46,9 +43,9 @@ export default function SceneCard({
     };
 
     return (
-        <div className={classes.sceneItem}>
-            <div className={classes.sceneTopRow}>{scene.name}</div>
-            <div className={classes.sceneBottomRow}>
+        <div className={classes.transitionItem}>
+            <div className={classes.transitionTopRow}>Transition</div>
+            <div className={classes.transitionBottomRow}>
                 <IconButton onClick={handleMenuClick}>
                     <MoreVertIcon />
                 </IconButton>
@@ -73,32 +70,7 @@ export default function SceneCard({
                         handleEditClick(scene.id);
                     }}
                 >
-                    Edit Metadata
-                </MenuItem>
-                <MenuItem>
-                    <a
-                        href={
-                            process.env.REACT_APP_ADMIN_BACKEND_URL +
-                            "/admin/scene/" +
-                            scene.id
-                        }
-                        target="_blank"
-                        rel="noreferrer"
-                        style={{
-                            textDecoration: "none",
-                            color: "#000",
-                        }}
-                    >
-                        Open Inspector
-                    </a>
-                </MenuItem>
-                <MenuItem
-                    onClick={() => {
-                        setAnchorEl(null);
-                        handleDeleteClick(scene.id);
-                    }}
-                >
-                    Delete Scene
+                    Edit Transitions
                 </MenuItem>
             </Menu>
         </div>


### PR DESCRIPTION
Video demo:
https://www.loom.com/share/72ce76ba1e6f46b491d959dfdea51ea7

What's working in this PR?
- ability to drag transition around with scene in scenario editor
- ability to click "edit transitions" and a modal shows up (using it's own variables)

Todos after this PR?
- actually fetch relevant data on the "edit transitions" click (it's using scene data and fields)
- actually edit transition data upon submitting the popup form