### PR TITLE
Auth consistency fixes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import "./App.css";
-import React from "react";
 import Routes from "./Routes";
 require("dotenv").config();
 import UserProvider from "./Providers/UserProviders.jsx";

--- a/src/Components/Admin/admin.js
+++ b/src/Components/Admin/admin.js
@@ -114,7 +114,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function Admin() {
     const classes = useStyles();
-    const user = useContext(UserContext);
+    const { user } = useContext(UserContext);
     const handleError = useErrorHandler();
 
     const [value, setValue] = React.useState("rooms");
@@ -287,7 +287,7 @@ export default function Admin() {
                     Admin Dashboard 😎
                 </Typography>
                 <Typography component="div" variant="h6">
-                    Welcome {user.displayName}
+                    Welcome {user?.displayName}
                 </Typography>
 
                 <div className={classes.root}>

--- a/src/Components/Admin/navbar.js
+++ b/src/Components/Admin/navbar.js
@@ -29,7 +29,6 @@ const useStyles = makeStyles(() => ({
 export default function Navbar({ home }) {
     const classes = useStyles();
     const history = useHistory();
-    const user = useContext(UserContext);
     const [anchorEl, setAnchorEl] = React.useState(null);
     const open = Boolean(anchorEl);
 
@@ -47,12 +46,14 @@ export default function Navbar({ home }) {
 
     async function handleLogout() {
         handleClose();
-        history.push("/login");
         auth.signOut();
         await httpGet(
             process.env.REACT_APP_ADMIN_BASE_ENDPOINT + "admin_logout"
         );
+        history.push("/login");
     }
+
+    const { isAdmin } = useContext(UserContext);
 
     return (
         <div className={classes.root}>
@@ -63,7 +64,7 @@ export default function Navbar({ home }) {
                             <HomeIcon />
                         </IconButton>
                     )}
-                    {user && (
+                    {isAdmin && (
                         <div className={classes.profileEnd}>
                             <IconButton
                                 aria-label="account of current user"

--- a/src/Providers/UserProviders.jsx
+++ b/src/Providers/UserProviders.jsx
@@ -20,10 +20,11 @@ class UserProvider extends Component {
                 const user = await generateUserDocument(userAuth);
                 this.setState({ user });
             }
-            // TODO: in the future do an authentication route that returns name and email of user?
+
+            // validate cookies are set appropriately on this user instance
             try {
-                const isValidUser = await httpGet(baseEndpoint + "scenarios");
-                this.setState({ isAdmin: isValidUser !== undefined });
+                const response = await httpGet(baseEndpoint + "user_profile");
+                this.setState({ isAdmin: response.status === 200 });
             } catch {
                 this.setState({ isAdmin: false });
             }

--- a/src/Providers/UserProviders.jsx
+++ b/src/Providers/UserProviders.jsx
@@ -1,10 +1,14 @@
 import React, { Component, createContext } from "react";
 import { auth, generateUserDocument } from "../firebaseCredentials.js";
+import { httpGet } from "../lib/dataAccess";
+
+const baseEndpoint = process.env.REACT_APP_ADMIN_BASE_ENDPOINT;
 
 export const UserContext = createContext({ user: null });
 class UserProvider extends Component {
     state = {
         user: null,
+        isAdmin: false,
     };
 
     componentDidMount = async () => {
@@ -16,12 +20,21 @@ class UserProvider extends Component {
                 const user = await generateUserDocument(userAuth);
                 this.setState({ user });
             }
+            // TODO: in the future do an authentication route that returns name and email of user?
+            try {
+                const isValidUser = await httpGet(baseEndpoint + "scenarios");
+                this.setState({ isAdmin: isValidUser !== undefined });
+            } catch {
+                this.setState({ isAdmin: false });
+            }
         });
     };
 
     render() {
         return (
-            <UserContext.Provider value={this.state.user}>
+            <UserContext.Provider
+                value={{ user: this.state.user, isAdmin: this.state.isAdmin }}
+            >
                 {this.props.children}
             </UserContext.Provider>
         );

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -31,6 +31,7 @@ export default function Routes() {
                 path="/admin/asset/:assetId"
                 component={AssetModelViewer}
             />
+            <Route exact path="/*" component={Admin} />
         </Switch>
     ) : (
         <Switch>
@@ -38,6 +39,7 @@ export default function Routes() {
             <Route exact path="/login" component={Login} />
             <Route exact path="/signup" component={Signup} />
             <Route exact path="/passwordReset" component={PasswordReset} />
+            <Route exact path="/*" component={Login} />
         </Switch>
     );
 }

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -11,9 +11,9 @@ import AssetModelViewer from "./Components/Admin/AssetModelViewer/assetModelView
 import { UserContext } from "./Providers/UserProviders";
 
 export default function Routes() {
-    const user = useContext(UserContext);
+    const { isAdmin } = useContext(UserContext);
 
-    return user ? (
+    return isAdmin ? (
         <Switch>
             <Route exact path="/admin" component={Admin} />
             <Route


### PR DESCRIPTION
Changes:
- implemented a second field within the UserContext that is the field which indicates whether we are logged in with a valid admin user
- this additional field only gets recomputed when auth state changes
- if tokens are still set, no issues (admin user maintains access)
- if tokens are lost, this will fail and show a 403, which in a previous PR I added an okay button which will handle all state issues and move go /login route
- kept "user" as we can use that to pull fields like `displayName` and other info that firebase stores

What to test:
- logical analysis of code for any edge case where we have invalid state
- try to duplicate this when running locally
- try basic login / logout / clear cookies flows

Loom video:
https://www.loom.com/share/fb739486a1a14868a947048ccbdfd6f0