### PR TITLE
Rearrange logout flow

### DIFF
--- a/src/Components/Admin/navbar.js
+++ b/src/Components/Admin/navbar.js
@@ -8,6 +8,7 @@ import AccountCircle from "@material-ui/icons/AccountCircle";
 import MenuItem from "@material-ui/core/MenuItem";
 import Menu from "@material-ui/core/Menu";
 import HomeIcon from "@material-ui/icons/Home";
+import { useErrorHandler } from "react-error-boundary";
 
 import { httpGet } from "../../lib/dataAccess";
 import { auth } from "../../firebaseCredentials";
@@ -29,6 +30,8 @@ const useStyles = makeStyles(() => ({
 export default function Navbar({ home }) {
     const classes = useStyles();
     const history = useHistory();
+    const handleError = useErrorHandler();
+
     const [anchorEl, setAnchorEl] = React.useState(null);
     const open = Boolean(anchorEl);
 
@@ -46,11 +49,16 @@ export default function Navbar({ home }) {
 
     async function handleLogout() {
         handleClose();
-        auth.signOut();
-        await httpGet(
-            process.env.REACT_APP_ADMIN_BASE_ENDPOINT + "admin_logout"
-        );
-        history.push("/login");
+
+        try {
+            await httpGet(
+                process.env.REACT_APP_ADMIN_BASE_ENDPOINT + "admin_logout"
+            );
+            auth.signOut();
+            history.push("/login");
+        } catch (error) {
+            handleError(error);
+        }
     }
 
     const { isAdmin } = useContext(UserContext);


### PR DESCRIPTION
This was an issue detected on prod (not sure why prod was making this a more visible issue since it didn't happen locally).

Basically, auth.signOut() was completing occasionally before the admin_logout endpoint is called. This causes admin_logout to error out with a 403 forbidden which was not getting caught since it was not in a try catch.

So this PR not only nests it within a try catch, but also rearranges so this 403 forbidden should not happen anymore.