### PR TITLE
Style scene card dropdown menu

### DIFF
--- a/src/Components/Admin/Scenes/sceneCard.js
+++ b/src/Components/Admin/Scenes/sceneCard.js
@@ -84,6 +84,37 @@ const useStyles = makeStyles(() => ({
         fontWeight: "bold",
         maxWidth: "75%",
     },
+    menuItem: {
+        "&:hover": {
+            background: Colours.MainRed1,
+            color: Colours.MainRed8,
+        },
+        "&:onclick": {
+            background: Colours.MainRed5,
+            color: Colours.White,
+        },
+        fontSize: 15,
+        paddingLeft: 18,
+        paddingRight: 18,
+        paddingTop: 8,
+        paddingBottom: 8,
+    },
+    menuItemDelete: {
+        "&:hover": {
+            background: Colours.MainRed1,
+            color: Colours.MainRed8,
+        },
+        "&:onclick": {
+            background: Colours.MainRed5,
+            color: Colours.White,
+        },
+        color: Colours.MainRed5,
+        fontSize: 15,
+        paddingLeft: 18,
+        paddingRight: 18,
+        paddingTop: 8,
+        paddingBottom: 10,
+    },
 }));
 
 export default function SceneCard({
@@ -177,18 +208,20 @@ export default function SceneCard({
                 <Menu
                     anchorEl={anchorEl}
                     anchorOrigin={{
-                        vertical: "top",
+                        vertical: "center",
                         horizontal: "center",
                     }}
                     transformOrigin={{
-                        vertical: "top",
-                        horizontal: "center",
+                        vertical: 0,
+                        horizontal: 150,
                     }}
+                    MenuListProps={{ disablePadding: true }}
                     keepMounted
                     open={open}
                     onClose={handleMenuClose}
                 >
                     <MenuItem
+                        className={classes.menuItem}
                         onClick={() => {
                             setAnchorEl(null);
                             handleDoubleClick();
@@ -197,22 +230,30 @@ export default function SceneCard({
                         Open Inspector
                     </MenuItem>
                     <MenuItem
+                        className={classes.menuItem}
                         onClick={() => {
                             setAnchorEl(null);
                             handleEditClick(data.id);
                         }}
+                        disabled
                     >
-                        Edit scene metadata
+                        Edit Metadata
                     </MenuItem>
-                    <MenuItem>Copy game link</MenuItem>
-                    <MenuItem>View stats</MenuItem>
+                    <MenuItem disabled className={classes.menuItem}>
+                        Copy Game Link
+                    </MenuItem>
+                    <MenuItem disabled className={classes.menuItem}>
+                        View Stats
+                    </MenuItem>
                     <MenuItem
+                        className={classes.menuItemDelete}
                         onClick={() => {
                             setAnchorEl(null);
                             handleDeleteClick(data.id);
                         }}
+                        disabled
                     >
-                        Delete scene
+                        Delete Scene
                     </MenuItem>
                 </Menu>
             </Grid>


### PR DESCRIPTION
Loom video: https://www.loom.com/share/e662438d18fe41a9a45b0004e8a61466

Please watch the video as I brought up a concern I had with the actual values in this dropdown, for now 4/5 are disabled because they do not do anything, so was wondering if there even is a use case for them moving forward.