### PR TITLE
Style asset card dropdown menu

### DIFF
--- a/src/Components/Admin/Assets/assetCard.js
+++ b/src/Components/Admin/Assets/assetCard.js
@@ -85,6 +85,37 @@ const useStyles = makeStyles(() => ({
         fontWeight: "bold",
         maxWidth: "75%",
     },
+    menuItem: {
+        "&:hover": {
+            background: Colours.MainRed1,
+            color: Colours.MainRed8,
+        },
+        "&:onclick": {
+            background: Colours.MainRed5,
+            color: Colours.White,
+        },
+        fontSize: 15,
+        paddingLeft: 18,
+        paddingRight: 18,
+        paddingTop: 8,
+        paddingBottom: 8,
+    },
+    menuItemDelete: {
+        "&:hover": {
+            background: Colours.MainRed1,
+            color: Colours.MainRed8,
+        },
+        "&:onclick": {
+            background: Colours.MainRed5,
+            color: Colours.White,
+        },
+        color: Colours.MainRed5,
+        fontSize: 15,
+        paddingLeft: 18,
+        paddingRight: 18,
+        paddingTop: 8,
+        paddingBottom: 10,
+    },
 }));
 
 export default function AssetCard({ data, handleDeleteClick }) {
@@ -186,6 +217,16 @@ export default function AssetCard({ data, handleDeleteClick }) {
                     onClose={handleMenuClose}
                 >
                     <MenuItem
+                        className={classes.menuItem}
+                        onClick={() => {
+                            setAnchorEl(null);
+                            handleDoubleClick();
+                        }}
+                    >
+                        View Asset
+                    </MenuItem>
+                    <MenuItem
+                        className={classes.menuItemDelete}
                         onClick={() => {
                             setAnchorEl(null);
                             handleDeleteClick(data.id);

--- a/src/Components/Admin/Rooms/roomCard.js
+++ b/src/Components/Admin/Rooms/roomCard.js
@@ -228,20 +228,32 @@ export default function RoomCard({
                         className={classes.menuItem}
                         onClick={() => {
                             setAnchorEl(null);
+                            handleDoubleClick();
+                        }}
+                    >
+                        View Editor
+                    </MenuItem>
+                    <MenuItem
+                        className={classes.menuItem}
+                        onClick={() => {
+                            setAnchorEl(null);
                             handleShareAndPublishClick(data.id);
                         }}
                     >
                         Share & Publish
                     </MenuItem>
-                    <MenuItem disabled className={classes.menuItem}>
-                        View Game Stats
-                    </MenuItem>
                     <Divider light />
-                    <MenuItem disabled className={classes.menuItem}>
+                    <MenuItem
+                        className={classes.menuItem}
+                        onClick={() => {
+                            setAnchorEl(null);
+                            navigator.clipboard.writeText(
+                                process.env.REACT_APP_ADMIN_DEPLOYED_URL +
+                                    `admin/environment/${data.id}`
+                            );
+                        }}
+                    >
                         Copy Editor Link
-                    </MenuItem>
-                    <MenuItem disabled className={classes.menuItem}>
-                        Duplicate
                     </MenuItem>
                     <MenuItem
                         className={classes.menuItem}


### PR DESCRIPTION
A few things done in this PR:
- Style asset card dropdown menu
- Add "view asset" option to asset dropdown
- Add "view editor" option to scenario dropdown
- Remove "duplicate" and "view game stats" options in scenario dropdown
- Enable "copy editor link" and make it copy the path to that editor

To do for all devs: add `REACT_APP_ADMIN_DEPLOYED_URL=https://interactive-admin.calgaryconnecteen.com/` to .env file in cdc-frontend repo.