### PR TITLE
Add rel noopener noreferrer to target blank link

### DIFF
--- a/src/Components/Admin/EnvironmentEditor/sceneCard.js
+++ b/src/Components/Admin/EnvironmentEditor/sceneCard.js
@@ -118,7 +118,7 @@ export default function SceneCard({
                             scene.id
                         }
                         target="_blank"
-                        rel="noreferrer"
+                        rel="noopener noreferrer"
                         style={{
                             textDecoration: "none",
                             color: "#000",


### PR DESCRIPTION
Read this article talking about how target="_blank" is not safe, and we should be using a rel attribute with noopener and noreferrer. Made this change in the only place we have a target="_blank" in the repo.

Article: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/