### PR TITLE
Restrict background assets functionality

### DIFF
--- a/src/Components/Admin/AssetModelViewer/assetModelViewer.js
+++ b/src/Components/Admin/AssetModelViewer/assetModelViewer.js
@@ -234,7 +234,7 @@ export default function AssetModelViewer({
                             <MenuItem value={ObjectTypes.OBJECT}>
                                 {ObjectTypes.OBJECT}
                             </MenuItem>
-                            <MenuItem value={ObjectTypes.BACKGROUND}>
+                            <MenuItem value={ObjectTypes.BACKGROUND} disabled>
                                 {ObjectTypes.BACKGROUND}
                             </MenuItem>
                         </Select>

--- a/src/Components/Admin/AssetModelViewer/assetModelViewer.js
+++ b/src/Components/Admin/AssetModelViewer/assetModelViewer.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import "@google/model-viewer";
+import { useHistory } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import Drawer from "@material-ui/core/Drawer";
 import CssBaseline from "@material-ui/core/CssBaseline";
@@ -14,6 +15,7 @@ import {
 } from "../../../lib/assetEndpoints";
 import { useErrorHandler } from "react-error-boundary";
 import SaveIcon from "@material-ui/icons/Save";
+import ArrowBack from "@material-ui/icons/ArrowBack";
 import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
 import FormControl from "@material-ui/core/FormControl";
@@ -59,6 +61,7 @@ export default function AssetModelViewer({
     },
 }) {
     const classes = useStyles();
+    const history = useHistory();
     const handleError = useErrorHandler();
     const [asset, setAsset] = useState({});
     const [name, setName] = useState("");
@@ -176,16 +179,32 @@ export default function AssetModelViewer({
                 }}
                 anchor="left"
             >
-                <div className={classes.toolbar} />
+                <div className={classes.toolbar}>
+                    <ArrowBack
+                        style={{
+                            width: 50,
+                            height: 50,
+                            paddingTop: 15,
+                            paddingLeft: 10,
+                            cursor: "pointer",
+                        }}
+                        onClick={() => {
+                            history.push("/admin");
+                        }}
+                    />
+                </div>
                 <Divider />
-
                 <form
                     className={classes.textfields}
                     noValidate
                     onSubmit={updateAsset}
                     autoComplete="off"
                 >
-                    <Typography variant="h6" align="center">
+                    <Typography
+                        variant="h6"
+                        align="center"
+                        style={{ marginTop: 20 }}
+                    >
                         Asset Model Viewer
                     </Typography>
                     <TextField
@@ -228,6 +247,7 @@ export default function AssetModelViewer({
                         color="primary"
                         startIcon={<SaveIcon />}
                         disabled={!isEmpty(nameError)}
+                        style={{ maxWidth: 250, marginLeft: 15 }}
                     >
                         {buttonText}
                     </Button>

--- a/src/Components/Admin/Assets/uploadAssetModal.js
+++ b/src/Components/Admin/Assets/uploadAssetModal.js
@@ -55,7 +55,7 @@ export default function UploadAssetModal({
 }) {
     const classes = useStyles();
     const [assetName, setAssetName] = React.useState("");
-    const [objectType, setObjectType] = React.useState(ObjectTypes.NONE);
+    const [objectType, setObjectType] = React.useState(ObjectTypes.OBJECT);
     const [fileType, setFileType] = React.useState(FileTypes.NONE);
     const [assetByteArray, setAssetByteArray] = React.useState(null);
     const [fileName, setFileName] = React.useState("");
@@ -197,9 +197,6 @@ export default function UploadAssetModal({
                         >
                             <MenuItem value={ObjectTypes.OBJECT}>
                                 {ObjectTypes.OBJECT}
-                            </MenuItem>
-                            <MenuItem value={ObjectTypes.BACKGROUND}>
-                                {ObjectTypes.BACKGROUND}
                             </MenuItem>
                         </Select>
                     </FormControl>


### PR DESCRIPTION
Two main items:
- cannot add a new asset as background
- cannot change an existing asset to background type

Loom demo: https://www.loom.com/share/578be864dad54121a05ffba7b4bccd6c
