### PR TITLE
Enable play button in environment editor

### DIFF
--- a/src/Components/Admin/EnvironmentEditor/environment.js
+++ b/src/Components/Admin/EnvironmentEditor/environment.js
@@ -439,7 +439,7 @@ export default function EnvironmentEditor({
                 <EnvironmentBar
                     onCreateButtonClick={onCreateButtonClick}
                     onTemplateButtonClick={onTemplateButtonClick}
-                    isEnvironment
+                    initialEnv={environment}
                 />
             </div>
             <div className={classes.container}>

--- a/src/Components/Admin/EnvironmentEditor/environmentBar.js
+++ b/src/Components/Admin/EnvironmentEditor/environmentBar.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useHistory } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
@@ -79,6 +80,7 @@ export default function EnvironmentBar({
     initialEnv,
 }) {
     const classes = useStyles();
+    const history = useHistory();
     const handleError = useErrorHandler();
 
     const [menuAnchorEl, setMenuAnchorEl] = useState(null);
@@ -222,7 +224,16 @@ export default function EnvironmentBar({
                             Share & Publish
                         </Button>
                         <Button>
-                            <PlayArrowIcon className={classes.preview} />
+                            <a
+                                href={
+                                    process.env.REACT_APP_DEPLOYED_URL +
+                                    environment.friendly_name
+                                }
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                <PlayArrowIcon className={classes.preview} />
+                            </a>
                         </Button>
                     </div>
                 </Toolbar>

--- a/src/Components/Admin/EnvironmentEditor/environmentBar.js
+++ b/src/Components/Admin/EnvironmentEditor/environmentBar.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { useHistory } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
@@ -80,7 +79,6 @@ export default function EnvironmentBar({
     initialEnv,
 }) {
     const classes = useStyles();
-    const history = useHistory();
     const handleError = useErrorHandler();
 
     const [menuAnchorEl, setMenuAnchorEl] = useState(null);


### PR DESCRIPTION
The play button in the top right of environment editor:
![image](https://user-images.githubusercontent.com/13268990/153069066-18a8db42-6a11-41e4-ad59-46f7e95da9a0.png)

When clicked will open a new tab with the student experience open (ie. http://localhost:8888/youth-in-crisis for local environment).